### PR TITLE
Drop table with cascade

### DIFF
--- a/pyspark_data_mocker/datalake_builder.py
+++ b/pyspark_data_mocker/datalake_builder.py
@@ -98,12 +98,8 @@ class DataLakeBuilder:
         return self
 
     def cleanup(self):
-        for table in self.tables:
-            if not self.spark_test.config or not self.spark_test.config.delta_configuration:
-                self.spark.sql(f"TRUNCATE TABLE {table['db_name']}.{table['table_name']}")
-            self.spark.sql(f"DROP TABLE {table['db_name']}.{table['table_name']}")
         for db in self.dbs:
-            self.spark.sql(f"DROP DATABASE IF EXISTS {db}")
+            self.spark.sql(f"DROP DATABASE IF EXISTS {db} CASCADE")
 
     def load_from_dir(self, datalake_dir: PathLike) -> "DataLakeBuilder":
         """


### PR DESCRIPTION
This will drop the databases even if there were tables created inside the test (and it is not mapped in the self.tables attribute)